### PR TITLE
Make drawer responsive and fix Chrome picker resizing bug

### DIFF
--- a/src/assets/styles/ColorPickerFormStyles.js
+++ b/src/assets/styles/ColorPickerFormStyles.js
@@ -1,3 +1,5 @@
+import sizes from './sizes';
+
 const styles = {
   picker: {
     // width: "100%",
@@ -9,6 +11,9 @@ const styles = {
     padding: "1rem",
     marginTop: "1rem",
     fontSize: "2rem",
+    [sizes.down("xs")]: {
+      fontSize: "1rem"
+    }
   },
   colorNameInput: {
     width: "100%",

--- a/src/assets/styles/NewPaletteFormStyles.js
+++ b/src/assets/styles/NewPaletteFormStyles.js
@@ -1,6 +1,8 @@
 // the drawer width is from "constants.js"
 import { DRAWER_WIDTH } from './../../constants';
+import sizes from './../styles/sizes';
 const drawerWidth = DRAWER_WIDTH;
+
 
 // "styles" is a function that accepts a "theme"; theme contains a bunch of useful things we don't have to create ourselves; it's part of material ui
 const styles = theme => ({
@@ -17,7 +19,10 @@ const styles = theme => ({
   drawerPaper: {
     width: drawerWidth,
     display: "flex",
-    alignItems: "center"
+    alignItems: "center",
+    [sizes.down("xs")]: {
+      width: "100%"
+    }
   },
   drawerHeader: {
     display: "flex",
@@ -57,8 +62,12 @@ const styles = theme => ({
     width: "100%"
   },
   button: {
-    width: "50%"
-  }
+    width: "50%",
+    [sizes.down("xs")]: {
+      width: "100%",
+      marginTop: "1rem"
+    }
+  },
 });
 
 export default styles;

--- a/src/containers/ColorPickerForm/index.js
+++ b/src/containers/ColorPickerForm/index.js
@@ -55,7 +55,7 @@ class ColorPickerForm extends Component {
     const { currentColor, newColorName } = this.state;
 
     return (
-      <div>
+      <div style={{ width: "inherit" }}>
         {/* 'onChangeComplete' gets called whenever we call a new color */}
         <ChromePicker color={currentColor} onChangeComplete={this.updateCurrentColor} className={classes.picker}/>
         <ValidatorForm onSubmit={this.handleSubmit} ref="form" instantValidate={false}>


### PR DESCRIPTION
- Add media queries to make drawer and buttons responsive
- Fix color picker resizing bug (color picker would change size if either the alpha slider was changed or the color format was changed; a style was added to the div that contained the color picker, so that it would inherit its parent container width)